### PR TITLE
More precise control over STS cross-reference TMap start and end day windows

### DIFF
--- a/notebooks/tensor-map-playground.ipynb
+++ b/notebooks/tensor-map-playground.ipynb
@@ -51,7 +51,7 @@
    "source": [
     "needed_tensor_maps = [\n",
     "#     \"atrial_fibrillation_365_days_post_sts\",\n",
-    "    \"atrial_fibrillation_90_to_364_days_post_sts\",\n",
+    "    \"atrial_fibrillation_any_90_to_364_days_post_sts\",\n",
     "#     \"ecg_age\",\n",
     "#     \"av_mean_gradient_365_days_post_ecg_newest\",\n",
     "#     \"av_peak_gradient\",\n",

--- a/notebooks/tensor-map-playground.ipynb
+++ b/notebooks/tensor-map-playground.ipynb
@@ -28,7 +28,7 @@
     "from matplotlib import pyplot as plt\n",
     "\n",
     "from ml4c3.datasets import train_valid_test_datasets\n",
-    "from ml4c3.tensormap.TensorMap import TensorMap, update_tmaps\n",
+    "from tensormap.TensorMap import TensorMap, update_tmaps\n",
     "from definitions.globals import TENSOR_EXT\n",
     "\n",
     "pp = pprint.PrettyPrinter(indent=4)\n",
@@ -50,7 +50,8 @@
    "outputs": [],
    "source": [
     "needed_tensor_maps = [\n",
-    "    \"c3po_death_10_years_pre_ecg\",\n",
+    "#     \"atrial_fibrillation_365_days_post_sts\",\n",
+    "    \"atrial_fibrillation_90_to_364_days_post_sts\",\n",
     "#     \"ecg_age\",\n",
     "#     \"av_mean_gradient_365_days_post_ecg_newest\",\n",
     "#     \"av_peak_gradient\",\n",
@@ -90,8 +91,8 @@
     "# 2. Tuple: first element is string path to CSV file, second element is friendly name\n",
     "tensors = [\n",
     "     \"/storage/shared/ecg/mgh\",\n",
-    "     (os.path.expanduser(\"~/dropbox/c3po/c3po.csv\"), \"c3po\"),\n",
-    "#    (os.path.expanduser(\"~/dropbox/sts-data/sts-mgh.csv\"), \"sts\"),\n",
+    "#      (os.path.expanduser(\"~/dropbox/c3po/c3po.csv\"), \"c3po\"),\n",
+    "   (os.path.expanduser(\"~/dropbox/sts-data/sts-patient-list.csv\"), \"sts\"),\n",
     "#    (os.path.expanduser(\"~/dropbox/ecgnet-as/data/edw/edw-echo.csv\"), \"echo\"),\n",
     "#    (os.path.expanduser(\"~/dropbox/ecgnet-as/data/edw/edw.csv\"), \"echo\"),\n",
     "]\n",
@@ -152,6 +153,13 @@
     "for key, value in batch.items():\n",
     "    print(f\"\\tTensorMap: {key} / Tensors: {value}\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Issues closed
Closes #1313

## Changelog
- [x] Support for TMaps such as `ecg_2500_std_30_to_180_days_pre_echo`, or `atrial_fibrillation_any_90_to_365_days_post_sts`.

## Checklist
- [x] The following are complete:
    - Added or revised tests if appropriate.
    - If new packages are installed, `requirements.txt` is updated.
    - If documentation should be updated, a new issue was made in `ml4c3-wiki`.
    - The PR name describes its content and does not contain "Ref #".
    - The PR does not add PHI.
